### PR TITLE
Fix scraping multiple interface implementations

### DIFF
--- a/pkg/internal/test/structures.go
+++ b/pkg/internal/test/structures.go
@@ -786,3 +786,40 @@ func NewRootWithPrivateFunctionReturningPointersComponentsImplementingOfHasInfoI
 		},
 	}
 }
+
+type PublicInterfaceImplA struct{}
+
+func (a PublicInterfaceImplA) Info() model.Info {
+	return model.ComponentInfo(
+		"test.PublicInterfaceImplA",
+		"public",
+	)
+}
+
+func (a PublicInterfaceImplA) DoSomethingPublic() {
+	panic("implement me")
+}
+
+type PublicInterfaceImplB struct{}
+
+func (b PublicInterfaceImplB) Info() model.Info {
+	return model.ComponentInfo(
+		"test.PublicInterfaceImplB",
+		"public",
+	)
+}
+
+func (b PublicInterfaceImplB) DoSomethingPublic() {
+	panic("implement me")
+}
+
+type RootWithPublicInterfaceProperty struct {
+	PI PublicInterface
+}
+
+func NewRootWithMultipleInterfaceImplementations() []RootWithPublicInterfaceProperty {
+	return []RootWithPublicInterfaceProperty{
+		{PI: PublicInterfaceImplA{}},
+		{PI: PublicInterfaceImplB{}},
+	}
+}

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -23,20 +23,18 @@ type Scraper interface {
 }
 
 type scraper struct {
-	config       Configuration
-	rules        []Rule
-	structure    model.Structure
-	scrapedTypes map[string]struct{}
+	config    Configuration
+	rules     []Rule
+	structure model.Structure
 }
 
 // NewScraper instantiates a default Scraper implementation
 // with provided Configuration.
 func NewScraper(config Configuration) Scraper {
 	return &scraper{
-		config:       config,
-		rules:        make([]Rule, 0),
-		structure:    model.NewStructure(),
-		scrapedTypes: map[string]struct{}{},
+		config:    config,
+		rules:     make([]Rule, 0),
+		structure: model.NewStructure(),
 	}
 }
 
@@ -59,10 +57,9 @@ func NewScraperFromConfigFile(fileName string) (Scraper, error) {
 	}
 
 	return &scraper{
-		config:       config,
-		rules:        rules,
-		structure:    model.NewStructure(),
-		scrapedTypes: map[string]struct{}{},
+		config:    config,
+		rules:     rules,
+		structure: model.NewStructure(),
 	}, nil
 }
 

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -15,7 +15,7 @@ const (
 	testPKG = "github.com/krzysztofreczek/go-structurizr/pkg/internal/test"
 )
 
-func TestScraper_Scrap_package_matching(t *testing.T) {
+func TestScraper_Scrape_package_matching(t *testing.T) {
 	var tests = []struct {
 		name                       string
 		structure                  interface{}
@@ -66,7 +66,7 @@ func TestScraper_Scrap_package_matching(t *testing.T) {
 	}
 }
 
-func TestScraper_Scrap_has_info_interface(t *testing.T) {
+func TestScraper_Scrape_has_info_interface(t *testing.T) {
 	c := scraper.NewConfiguration(
 		testPKG,
 	)
@@ -666,6 +666,15 @@ func TestScraper_Scrap_has_info_interface(t *testing.T) {
 			},
 			expectedRelations: map[string][]string{},
 		},
+		{
+			name:      "root with multiple interface implementation",
+			structure: test.NewRootWithMultipleInterfaceImplementations(),
+			expectedComponentIDs: map[string]struct{}{
+				componentID("PublicInterfaceImplA"): {},
+				componentID("PublicInterfaceImplB"): {},
+			},
+			expectedRelations: map[string][]string{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -677,7 +686,7 @@ func TestScraper_Scrap_has_info_interface(t *testing.T) {
 	}
 }
 
-func TestScraper_Scrap_has_info_interface_component_info(t *testing.T) {
+func TestScraper_Scrape_has_info_interface_component_info(t *testing.T) {
 	c := scraper.NewConfiguration(
 		testPKG,
 	)
@@ -724,7 +733,7 @@ func TestScraper_Scrap_has_info_interface_component_info(t *testing.T) {
 	}
 }
 
-func TestScraper_Scrap_rules(t *testing.T) {
+func TestScraper_Scrape_rules(t *testing.T) {
 	c := scraper.NewConfiguration(
 		testPKG,
 	)

--- a/pkg/scraper/strategy.go
+++ b/pkg/scraper/strategy.go
@@ -20,19 +20,6 @@ func (s *scraper) scrape(
 		return
 	}
 
-	nodeID := nodeID(v, parentID)
-
-	if v.Type().String() == "model.HasInfo" {
-
-	} else if v.Kind() != reflect.Struct {
-
-	} else if _, scraped := s.scrapedTypes[nodeID]; !scraped {
-		s.scrapedTypes[nodeID] = struct{}{}
-	} else {
-		s.debug(v, "value has already been processed")
-		return
-	}
-
 	strategy := s.resolveScrapingStrategy(v)
 	strategy(v, parentID, level)
 }
@@ -264,11 +251,6 @@ func (s *scraper) getInfoFromRules(v reflect.Value) (model.Info, bool) {
 
 	s.debug(v, "there was no rule applicable for this value")
 	return model.Info{}, false
-}
-
-func nodeID(v reflect.Value, parentID string) string {
-	id := fmt.Sprintf("%s.%s.%s", parentID, valuePackage(v), v.Type().Name())
-	return internal.Hash(id)
 }
 
 func componentID(v reflect.Value) string {


### PR DESCRIPTION
This PR fixes a scenario where there was a structure with multiple implementations of an interface property. Because of a logic that is skipping already-scraped structs, we were not capturing all of the implementations existing in the model.